### PR TITLE
Remove unsupported features

### DIFF
--- a/pcextreme.go
+++ b/pcextreme.go
@@ -102,18 +102,6 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			EnvVar: "pcextreme_TIMEOUT",
 			Value:  300,
 		},
-		mcnflag.BoolFlag{
-			Name:  "pcextreme-use-private-address",
-			Usage: "Use a private IP to access the machine",
-		},
-		mcnflag.BoolFlag{
-			Name:  "pcextreme-use-port-forward",
-			Usage: "Use port forwarding rule to access the machine",
-		},
-		mcnflag.StringFlag{
-			Name:  "pcextreme-public-ip",
-			Usage: "pcextreme Public IP",
-		},
 		mcnflag.StringFlag{
 			Name:   "pcextreme-ssh-user",
 			Usage:  "pcextreme SSH user",
@@ -123,10 +111,6 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		mcnflag.StringSliceFlag{
 			Name:  "pcextreme-cidr",
 			Usage: "Source CIDR to give access to the machine. default 0.0.0.0/0",
-		},
-		mcnflag.BoolFlag{
-			Name:  "pcextreme-expunge",
-			Usage: "Whether or not to expunge the machine upon removal",
 		},
 		mcnflag.StringFlag{
 			Name:   "pcextreme-template",
@@ -147,15 +131,6 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage: "pcextreme service offering id",
 		},
 		mcnflag.StringFlag{
-			Name:   "pcextreme-network",
-			Usage:  "pcextreme network",
-			EnvVar: "pcextreme_NETWORK",
-		},
-		mcnflag.StringFlag{
-			Name:  "pcextreme-network-id",
-			Usage: "pcextreme network id",
-		},
-		mcnflag.StringFlag{
 			Name:   "pcextreme-zone",
 			Usage:  "pcextreme zone",
 			EnvVar: "pcextreme_ZONE",
@@ -168,14 +143,6 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:   "pcextreme-userdata-file",
 			Usage:  "pcextreme Userdata file",
 			EnvVar: "pcextreme_USERDATA_FILE",
-		},
-		mcnflag.StringFlag{
-			Name:  "pcextreme-project",
-			Usage: "pcextreme project",
-		},
-		mcnflag.StringFlag{
-			Name:  "pcextreme-project-id",
-			Usage: "pcextreme project id",
 		},
 		mcnflag.StringSliceFlag{
 			Name:  "pcextreme-resource-tag",

--- a/pcextreme.go
+++ b/pcextreme.go
@@ -270,6 +270,7 @@ func (d *Driver) GetURL() (string, error) {
 
 // GetIP returns the IP that this host is available at
 func (d *Driver) GetIP() (string, error) {
+	return d.IPAddress, nil
 }
 
 // GetState returns the state that the host is in (running, stopped, etc)
@@ -345,6 +346,10 @@ func (d *Driver) Create() error {
 			p.SetSize(int64(d.DiskSize))
 		}
 	}
+	if err := d.createSecurityGroup(); err != nil {
+		return err
+	}
+	p.SetSecuritygroupnames([]string{d.MachineName})
 	log.Info("Creating CloudStack instance...")
 	vm, err := cs.VirtualMachine.DeployVirtualMachine(p)
 	if err != nil {
@@ -356,6 +361,8 @@ func (d *Driver) Create() error {
 			return err
 		}
 	}
+
+	d.IPAddress = vm.Nic[0].Ipaddress
 
 	return nil
 }
@@ -371,6 +378,8 @@ func (d *Driver) Remove() error {
 	if _, err := cs.VirtualMachine.DestroyVirtualMachine(p); err != nil {
 		return err
 	}
+	if err := d.deleteSecurityGroup(); err != nil {
+		return err
 	}
 	if d.DeleteVolumes {
 		if err := d.deleteVolumes(); err != nil {
@@ -485,6 +494,9 @@ func (d *Driver) setZone(zone string, zoneID string) error {
 
 	d.Zone = z.Name
 	d.ZoneID = z.Id
+
+	log.Debugf("zone: %q", d.Zone)
+	log.Debugf("zone id: %q", d.ZoneID)
 
 	return nil
 }

--- a/pcextreme.go
+++ b/pcextreme.go
@@ -44,7 +44,6 @@ type Driver struct {
 	SecretKey            string
 	HTTPGETOnly          bool
 	JobTimeOut           int64
-	UsePortForward       bool
 	PublicIP             string
 	PublicIPID           string
 	DisassociatePublicIP bool
@@ -250,7 +249,6 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.ApiURL = flags.String("pcextreme-api-url")
 	d.ApiKey = flags.String("pcextreme-api-key")
 	d.SecretKey = flags.String("pcextreme-secret-key")
-	d.UsePortForward = flags.Bool("pcextreme-use-port-forward")
 	d.HTTPGETOnly = flags.Bool("pcextreme-http-get-only")
 	d.JobTimeOut = int64(flags.Int("pcextreme-timeout"))
 	d.SSHUser = flags.String("pcextreme-ssh-user")
@@ -429,15 +427,6 @@ func (d *Driver) Create() error {
 		}
 		if err := d.configureFirewallRules(); err != nil {
 			return err
-		}
-		if d.UsePortForward {
-			if err := d.configurePortForwardingRules(); err != nil {
-				return err
-			}
-		} else {
-			if err := d.enableStaticNat(); err != nil {
-				return err
-			}
 		}
 	}
 	if len(d.Tags) > 0 {

--- a/pcextreme.go
+++ b/pcextreme.go
@@ -1,0 +1,1313 @@
+package pcextreme
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"crypto/md5"
+	"net/http"
+
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/docker/machine/libmachine/log"
+	"github.com/docker/machine/libmachine/mcnflag"
+	"github.com/docker/machine/libmachine/ssh"
+	"github.com/docker/machine/libmachine/state"
+	"github.com/pkg/errors"
+	"github.com/xanzy/go-cloudstack/cloudstack"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	driverName   = "pcextreme"
+	dockerPort   = 2376
+	swarmPort    = 3376
+	diskDatadisk = "DATADISK"
+)
+
+var keyExists bool
+
+type configError struct {
+	option string
+}
+
+func (e *configError) Error() string {
+	return fmt.Sprintf("PCextreme driver requires the --pcextreme-%s option", e.option)
+}
+
+type Driver struct {
+	*drivers.BaseDriver
+	Id                   string
+	ApiURL               string
+	ApiKey               string
+	SecretKey            string
+	HTTPGETOnly          bool
+	JobTimeOut           int64
+	UsePrivateIP         bool
+	UsePortForward       bool
+	PublicIP             string
+	PublicIPID           string
+	DisassociatePublicIP bool
+	SSHKeyPair           string
+	PrivateIP            string
+	CIDRList             []string
+	FirewallRuleIds      []string
+	Expunge              bool
+	Template             string
+	TemplateID           string
+	ServiceOffering      string
+	ServiceOfferingID    string
+	DeleteVolumes        bool
+	DiskOffering         string
+	DiskOfferingID       string
+	DiskSize             int
+	Network              string
+	NetworkID            string
+	Zone                 string
+	ZoneID               string
+	NetworkType          string
+	UserDataFile         string
+	UserData             string
+	Project              string
+	ProjectID            string
+	Tags                 []string
+	DisplayName          string
+}
+
+type UserDataYAML struct {
+	SSHAuthorizedKeys []string `yaml:"ssh_authorized_keys,omitempty"`
+	SSHKeys           struct {
+		RSAPrivate string `yaml:"rsa_private,omitempty"`
+		DSAPrivate string `yaml:"dsa_private,omitempty"`
+		RSAPublic  string `yaml:"rsa_public,omitempty"`
+		DSAPublic  string `yaml:"dsa_public,omitempty"`
+	} `yaml:"ssh_keys,omitempty"`
+}
+
+// GetCreateFlags registers the flags this driver adds to
+// "docker hosts create"
+func (d *Driver) GetCreateFlags() []mcnflag.Flag {
+	return []mcnflag.Flag{
+		mcnflag.StringFlag{
+			Name:   "pcextreme-api-url",
+			Usage:  "pcextreme API URL",
+			EnvVar: "pcextreme_API_URL",
+		},
+		mcnflag.StringFlag{
+			Name:   "pcextreme-api-key",
+			Usage:  "pcextreme API key",
+			EnvVar: "pcextreme_API_KEY",
+		},
+		mcnflag.StringFlag{
+			Name:   "pcextreme-secret-key",
+			Usage:  "pcextreme API secret key",
+			EnvVar: "pcextreme_SECRET_KEY",
+		},
+		mcnflag.BoolFlag{
+			Name:   "pcextreme-http-get-only",
+			Usage:  "Only use HTTP GET to execute pcextreme API",
+			EnvVar: "pcextreme_HTTP_GET_ONLY",
+		},
+		mcnflag.IntFlag{
+			Name:   "pcextreme-timeout",
+			Usage:  "time(seconds) allowed to complete async job",
+			EnvVar: "pcextreme_TIMEOUT",
+			Value:  300,
+		},
+		mcnflag.BoolFlag{
+			Name:  "pcextreme-use-private-address",
+			Usage: "Use a private IP to access the machine",
+		},
+		mcnflag.BoolFlag{
+			Name:  "pcextreme-use-port-forward",
+			Usage: "Use port forwarding rule to access the machine",
+		},
+		mcnflag.StringFlag{
+			Name:  "pcextreme-public-ip",
+			Usage: "pcextreme Public IP",
+		},
+		mcnflag.StringFlag{
+			Name:   "pcextreme-ssh-user",
+			Usage:  "pcextreme SSH user",
+			Value:  "root",
+			EnvVar: "pcextreme_SSH_USER",
+		},
+		mcnflag.StringSliceFlag{
+			Name:  "pcextreme-cidr",
+			Usage: "Source CIDR to give access to the machine. default 0.0.0.0/0",
+		},
+		mcnflag.BoolFlag{
+			Name:  "pcextreme-expunge",
+			Usage: "Whether or not to expunge the machine upon removal",
+		},
+		mcnflag.StringFlag{
+			Name:   "pcextreme-template",
+			Usage:  "pcextreme template",
+			EnvVar: "pcextreme_TEMPLATE",
+		},
+		mcnflag.StringFlag{
+			Name:  "pcextreme-template-id",
+			Usage: "pcextreme template id",
+		},
+		mcnflag.StringFlag{
+			Name:   "pcextreme-service-offering",
+			Usage:  "pcextreme service offering",
+			EnvVar: "pcextreme_SERVICE_OFFERING",
+		},
+		mcnflag.StringFlag{
+			Name:  "pcextreme-service-offering-id",
+			Usage: "pcextreme service offering id",
+		},
+		mcnflag.StringFlag{
+			Name:   "pcextreme-network",
+			Usage:  "pcextreme network",
+			EnvVar: "pcextreme_NETWORK",
+		},
+		mcnflag.StringFlag{
+			Name:  "pcextreme-network-id",
+			Usage: "pcextreme network id",
+		},
+		mcnflag.StringFlag{
+			Name:   "pcextreme-zone",
+			Usage:  "pcextreme zone",
+			EnvVar: "pcextreme_ZONE",
+		},
+		mcnflag.StringFlag{
+			Name:  "pcextreme-zone-id",
+			Usage: "pcextreme zone id",
+		},
+		mcnflag.StringFlag{
+			Name:   "pcextreme-userdata-file",
+			Usage:  "pcextreme Userdata file",
+			EnvVar: "pcextreme_USERDATA_FILE",
+		},
+		mcnflag.StringFlag{
+			Name:  "pcextreme-project",
+			Usage: "pcextreme project",
+		},
+		mcnflag.StringFlag{
+			Name:  "pcextreme-project-id",
+			Usage: "pcextreme project id",
+		},
+		mcnflag.StringSliceFlag{
+			Name:  "pcextreme-resource-tag",
+			Usage: "key:value resource tags to be created",
+		},
+		mcnflag.StringFlag{
+			Name:   "pcextreme-disk-offering",
+			Usage:  "pcextreme disk offering",
+			EnvVar: "pcextreme_DISK_OFFERING",
+		},
+		mcnflag.StringFlag{
+			Name:  "pcextreme-disk-offering-id",
+			Usage: "pcextreme disk offering id",
+		},
+		mcnflag.IntFlag{
+			Name:   "pcextreme-disk-size",
+			Usage:  "Disk offering custom size",
+			EnvVar: "pcextreme_CUSTOM_DISK_SIZE",
+		},
+		mcnflag.BoolFlag{
+			Name:  "pcextreme-delete-volumes",
+			Usage: "Whether or not to delete data volumes associated with the machine upon removal",
+		},
+		mcnflag.StringFlag{
+			Name:  "pcextreme-displayname",
+			Usage: "pcextreme virtual machine displayname",
+		},
+	}
+}
+
+func NewDriver(hostName, storePath string) drivers.Driver {
+	driver := &Driver{
+		BaseDriver: &drivers.BaseDriver{
+			MachineName: hostName,
+			StorePath:   storePath,
+		},
+		FirewallRuleIds: []string{},
+	}
+	return driver
+}
+
+// DriverName returns the name of the driver as it is registered
+func (d *Driver) DriverName() string {
+	return driverName
+}
+
+func (d *Driver) GetSSHHostname() (string, error) {
+	return d.GetIP()
+}
+
+func (d *Driver) GetSSHUsername() string {
+	if d.SSHUser == "" {
+		d.SSHUser = "root"
+	}
+	return d.SSHUser
+}
+
+// SetConfigFromFlags configures the driver with the object that was returned
+// by RegisterCreateFlags
+func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
+	d.ApiURL = flags.String("pcextreme-api-url")
+	d.ApiKey = flags.String("pcextreme-api-key")
+	d.SecretKey = flags.String("pcextreme-secret-key")
+	d.UsePrivateIP = flags.Bool("pcextreme-use-private-address")
+	d.UsePortForward = flags.Bool("pcextreme-use-port-forward")
+	d.HTTPGETOnly = flags.Bool("pcextreme-http-get-only")
+	d.JobTimeOut = int64(flags.Int("pcextreme-timeout"))
+	d.SSHUser = flags.String("pcextreme-ssh-user")
+	d.CIDRList = flags.StringSlice("pcextreme-cidr")
+	d.Expunge = flags.Bool("pcextreme-expunge")
+	d.Tags = flags.StringSlice("pcextreme-resource-tag")
+	d.DeleteVolumes = flags.Bool("pcextreme-delete-volumes")
+	d.DiskSize = flags.Int("pcextreme-disk-size")
+	d.DisplayName = flags.String("pcextreme-displayname")
+	d.SwarmMaster = flags.Bool("swarm-master")
+	d.SwarmDiscovery = flags.String("swarm-discovery")
+	if err := d.setProject(flags.String("pcextreme-project"), flags.String("pcextreme-project-id")); err != nil {
+		return err
+	}
+	if err := d.setZone(flags.String("pcextreme-zone"), flags.String("pcextreme-zone-id")); err != nil {
+		return err
+	}
+	if err := d.setTemplate(flags.String("pcextreme-template"), flags.String("pcextreme-template-id")); err != nil {
+		return err
+	}
+	if err := d.setServiceOffering(flags.String("pcextreme-service-offering"), flags.String("pcextreme-service-offering-id")); err != nil {
+		return err
+	}
+	if err := d.setNetwork(flags.String("pcextreme-network"), flags.String("pcextreme-network-id")); err != nil {
+		return err
+	}
+	if err := d.setPublicIP(flags.String("pcextreme-public-ip")); err != nil {
+		return err
+	}
+	if err := d.setUserData(flags.String("pcextreme-userdata-file")); err != nil {
+		return err
+	}
+	if err := d.setDiskOffering(flags.String("pcextreme-disk-offering"), flags.String("pcextreme-disk-offering-id")); err != nil {
+		return err
+	}
+	if d.DisplayName == "" {
+		d.DisplayName = d.MachineName
+	}
+	d.SSHKeyPair = d.MachineName
+	if d.ApiURL == "" {
+		return &configError{option: "api-url"}
+	}
+	if d.ApiKey == "" {
+		return &configError{option: "api-key"}
+	}
+	if d.SecretKey == "" {
+		return &configError{option: "secret-key"}
+	}
+	if d.Template == "" {
+		return &configError{option: "template"}
+	}
+	if d.ServiceOffering == "" {
+		return &configError{option: "service-offering"}
+	}
+	if d.Zone == "" {
+		return &configError{option: "zone"}
+	}
+	if len(d.CIDRList) == 0 {
+		d.CIDRList = []string{"0.0.0.0/0"}
+	}
+	d.DisassociatePublicIP = false
+	return nil
+}
+
+// GetURL returns a Docker compatible host URL for connecting to this host
+// e.g. tcp://1.2.3.4:2376
+func (d *Driver) GetURL() (string, error) {
+	ip, err := d.GetIP()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("tcp://%s:%d", ip, dockerPort), nil
+}
+
+// GetIP returns the IP that this host is available at
+func (d *Driver) GetIP() (string, error) {
+	if d.UsePrivateIP {
+		return d.PrivateIP, nil
+	}
+	return d.PublicIP, nil
+}
+
+// GetState returns the state that the host is in (running, stopped, etc)
+func (d *Driver) GetState() (state.State, error) {
+	cs := d.getClient()
+	vm, count, err := cs.VirtualMachine.GetVirtualMachineByID(d.Id, d.setParams)
+	if err != nil {
+		return state.Error, err
+	}
+
+	if count == 0 {
+		return state.None, fmt.Errorf("Machine does not exist, use create command to create it")
+	}
+
+	switch vm.State {
+	case "Starting":
+		return state.Starting, nil
+	case "Running":
+		return state.Running, nil
+	case "Stopping":
+		return state.Running, nil
+	case "Stopped":
+		return state.Stopped, nil
+	case "Destroyed":
+		return state.Stopped, nil
+	case "Expunging":
+		return state.Stopped, nil
+	case "Migrating":
+		return state.Paused, nil
+	case "Error":
+		return state.Error, nil
+	case "Unknown":
+		return state.Error, nil
+	case "Shutdowned":
+		return state.Stopped, nil
+	}
+
+	return state.None, nil
+}
+
+// PreCreate allows for pre-create operations to make sure a driver is ready for creation
+func (d *Driver) PreCreateCheck() error {
+	if err := d.checkKeyPairByName(); err != nil {
+		return err
+	}
+
+	if err := d.checkInstance(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Create a host using the driver's config
+func (d *Driver) Create() error {
+	cs := d.getClient()
+
+	if err := d.createKeyPair(); err != nil {
+		return err
+	}
+	p := cs.VirtualMachine.NewDeployVirtualMachineParams(
+		d.ServiceOfferingID, d.TemplateID, d.ZoneID)
+	p.SetName(d.MachineName)
+	p.SetDisplayname(d.DisplayName)
+	log.Infof("Setting Keypair for VM: %s", d.SSHKeyPair)
+	p.SetKeypair(d.SSHKeyPair)
+	if d.UserData != "" {
+		p.SetUserdata(d.UserData)
+	}
+	if d.NetworkID != "" {
+		p.SetNetworkids([]string{d.NetworkID})
+	}
+	if d.ProjectID != "" {
+		p.SetProjectid(d.ProjectID)
+	}
+	if d.DiskOfferingID != "" {
+		p.SetDiskofferingid(d.DiskOfferingID)
+		if d.DiskSize != 0 {
+			p.SetSize(int64(d.DiskSize))
+		}
+	}
+	if d.NetworkType == "Basic" {
+		if err := d.createSecurityGroup(); err != nil {
+			return err
+		}
+		p.SetSecuritygroupnames([]string{d.MachineName})
+	}
+	log.Info("Creating CloudStack instance...")
+	vm, err := cs.VirtualMachine.DeployVirtualMachine(p)
+	if err != nil {
+		return err
+	}
+	d.Id = vm.Id
+	d.PrivateIP = vm.Nic[0].Ipaddress
+	if d.NetworkType == "Basic" {
+		d.PublicIP = d.PrivateIP
+	}
+	if d.NetworkType == "Advanced" && !d.UsePrivateIP {
+		if d.PublicIPID == "" {
+			if err := d.associatePublicIP(); err != nil {
+				return err
+			}
+		}
+		if err := d.configureFirewallRules(); err != nil {
+			return err
+		}
+		if d.UsePortForward {
+			if err := d.configurePortForwardingRules(); err != nil {
+				return err
+			}
+		} else {
+			if err := d.enableStaticNat(); err != nil {
+				return err
+			}
+		}
+	}
+	if len(d.Tags) > 0 {
+		if err := d.createTags(); err != nil {
+			return err
+		}
+	}
+
+	d.IPAddress = d.PrivateIP
+
+	return nil
+}
+
+// Remove a host
+func (d *Driver) Remove() error {
+	cs := d.getClient()
+	p := cs.VirtualMachine.NewDestroyVirtualMachineParams(d.Id)
+	p.SetExpunge(d.Expunge)
+	if err := d.deleteFirewallRules(); err != nil {
+		return err
+	}
+	if err := d.disassociatePublicIP(); err != nil {
+		return err
+	}
+	if err := d.deleteKeyPair(); err != nil {
+		return err
+	}
+	log.Info("Removing PCextreme instance...")
+	if _, err := cs.VirtualMachine.DestroyVirtualMachine(p); err != nil {
+		return err
+	}
+	if d.NetworkType == "Basic" {
+		if err := d.deleteSecurityGroup(); err != nil {
+			return err
+		}
+	}
+	if d.DeleteVolumes {
+		if err := d.deleteVolumes(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Start a host
+func (d *Driver) Start() error {
+	vmstate, err := d.GetState()
+	if err != nil {
+		return err
+	}
+
+	if vmstate == state.Running {
+		log.Info("Machine is already running")
+		return nil
+	}
+
+	if vmstate == state.Starting {
+		log.Info("Machine is already starting")
+		return nil
+	}
+
+	cs := d.getClient()
+	p := cs.VirtualMachine.NewStartVirtualMachineParams(d.Id)
+
+	if _, err = cs.VirtualMachine.StartVirtualMachine(p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Stop a host gracefully
+func (d *Driver) Stop() error {
+	vmstate, err := d.GetState()
+	if err != nil {
+		return err
+	}
+
+	if vmstate == state.Stopped {
+		log.Info("Machine is already stopped")
+		return nil
+	}
+
+	cs := d.getClient()
+	p := cs.VirtualMachine.NewStopVirtualMachineParams(d.Id)
+
+	if _, err = cs.VirtualMachine.StopVirtualMachine(p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Restart a host.
+func (d *Driver) Restart() error {
+	vmstate, err := d.GetState()
+	if err != nil {
+		return err
+	}
+
+	if vmstate == state.Stopped {
+		return fmt.Errorf("Machine is stopped, use start command to start it")
+	}
+
+	cs := d.getClient()
+	p := cs.VirtualMachine.NewRebootVirtualMachineParams(d.Id)
+
+	if _, err = cs.VirtualMachine.RebootVirtualMachine(p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Kill stops a host forcefully
+func (d *Driver) Kill() error {
+	return d.Stop()
+}
+
+func (d *Driver) getClient() *cloudstack.CloudStackClient {
+	cs := cloudstack.NewAsyncClient(d.ApiURL, d.ApiKey, d.SecretKey, false)
+	cs.HTTPGETOnly = d.HTTPGETOnly
+	cs.AsyncTimeout(d.JobTimeOut)
+	return cs
+}
+
+func (d *Driver) setZone(zone string, zoneID string) error {
+	d.Zone = zone
+	d.ZoneID = zoneID
+	d.NetworkType = ""
+
+	if d.Zone == "" && d.ZoneID == "" {
+		return nil
+	}
+
+	cs := d.getClient()
+
+	var z *cloudstack.Zone
+	var err error
+	if d.ZoneID != "" {
+		z, _, err = cs.Zone.GetZoneByID(d.ZoneID, d.setParams)
+	} else {
+		z, _, err = cs.Zone.GetZoneByName(d.Zone, d.setParams)
+	}
+	if err != nil {
+		return fmt.Errorf("Unable to get zone: %v", err)
+	}
+
+	d.Zone = z.Name
+	d.ZoneID = z.Id
+	d.NetworkType = z.Networktype
+
+	log.Debugf("zone: %q", d.Zone)
+	log.Debugf("zone id: %q", d.ZoneID)
+	log.Debugf("network type: %q", d.NetworkType)
+
+	return nil
+}
+
+func (d *Driver) setTemplate(templateName string, templateID string) error {
+	d.Template = templateName
+	d.TemplateID = templateID
+
+	if d.Template == "" && d.TemplateID == "" {
+		return nil
+	}
+
+	if d.ZoneID == "" {
+		return fmt.Errorf("Unable to get template: zone is not set")
+	}
+
+	cs := d.getClient()
+	var template *cloudstack.Template
+	var err error
+	if d.TemplateID != "" {
+		template, _, err = cs.Template.GetTemplateByID(d.TemplateID, "executable", d.setParams)
+	} else {
+		template, _, err = cs.Template.GetTemplateByName(d.Template, "executable", d.ZoneID, d.setParams)
+	}
+	if err != nil {
+		return fmt.Errorf("Unable to get template: %v", err)
+	}
+
+	d.TemplateID = template.Id
+	d.Template = template.Name
+
+	log.Debugf("template id: %q", d.TemplateID)
+	log.Debugf("template name: %q", d.Template)
+
+	return nil
+}
+
+func (d *Driver) setServiceOffering(serviceoffering string, serviceofferingID string) error {
+	d.ServiceOffering = serviceoffering
+	d.ServiceOfferingID = serviceofferingID
+
+	if d.ServiceOffering == "" && d.ServiceOfferingID == "" {
+		return nil
+	}
+
+	cs := d.getClient()
+	var service *cloudstack.ServiceOffering
+	var err error
+	if d.ServiceOfferingID != "" {
+		service, _, err = cs.ServiceOffering.GetServiceOfferingByID(d.ServiceOfferingID, d.setParams)
+	} else {
+		service, _, err = cs.ServiceOffering.GetServiceOfferingByName(d.ServiceOffering, d.setParams)
+	}
+	if err != nil {
+		return fmt.Errorf("Unable to get service offering: %v", err)
+	}
+
+	d.ServiceOfferingID = service.Id
+	d.ServiceOffering = service.Name
+
+	log.Debugf("service offering id: %q", d.ServiceOfferingID)
+	log.Debugf("service offering name: %q", d.ServiceOffering)
+
+	return nil
+}
+
+func (d *Driver) setDiskOffering(diskOffering string, diskOfferingID string) error {
+	d.DiskOffering = diskOffering
+	d.DiskOfferingID = diskOfferingID
+
+	if d.DiskOffering == "" && d.DiskOfferingID == "" {
+		return nil
+	}
+
+	cs := d.getClient()
+	var disk *cloudstack.DiskOffering
+	var err error
+	if d.DiskOfferingID != "" {
+		disk, _, err = cs.DiskOffering.GetDiskOfferingByID(d.DiskOfferingID, d.setParams)
+	} else {
+		disk, _, err = cs.DiskOffering.GetDiskOfferingByName(d.DiskOffering, d.setParams)
+	}
+	if err != nil {
+		return fmt.Errorf("Unable to get disk offering: %v", err)
+	}
+
+	d.DiskOfferingID = disk.Id
+	d.DiskOffering = disk.Name
+
+	log.Debugf("disk offering id: %q", d.DiskOfferingID)
+	log.Debugf("disk offering name: %q", d.DiskOffering)
+
+	return nil
+}
+
+func (d *Driver) setNetwork(networkName string, networkID string) error {
+	d.Network = networkName
+	d.NetworkID = networkID
+
+	if d.Network == "" && d.NetworkID == "" {
+		return nil
+	}
+
+	cs := d.getClient()
+	var network *cloudstack.Network
+	var err error
+	if d.NetworkID != "" {
+		network, _, err = cs.Network.GetNetworkByID(d.NetworkID, d.setParams)
+	} else {
+		network, _, err = cs.Network.GetNetworkByName(d.Network, d.setParams)
+	}
+	if err != nil {
+		return fmt.Errorf("Unable to get network: %v", err)
+	}
+
+	d.NetworkID = network.Id
+	d.Network = network.Name
+
+	log.Debugf("network id: %q", d.NetworkID)
+	log.Debugf("network name: %q", d.Network)
+
+	return nil
+}
+
+func (d *Driver) setPublicIP(publicip string) error {
+	d.PublicIP = publicip
+	d.PublicIPID = ""
+
+	if d.PublicIP == "" {
+		return nil
+	}
+
+	cs := d.getClient()
+	p := cs.Address.NewListPublicIpAddressesParams()
+	p.SetIpaddress(d.PublicIP)
+	ips, err := cs.Address.ListPublicIpAddresses(p)
+	if err != nil {
+		return fmt.Errorf("Unable to get public ip id: %s", err)
+	}
+	if ips.Count < 1 {
+		return fmt.Errorf("Unable to get public ip id: Not Found %s", d.PublicIP)
+	}
+
+	d.PublicIPID = ips.PublicIpAddresses[0].Id
+
+	log.Debugf("public ip id: %q", d.PublicIPID)
+
+	return nil
+}
+
+func (d *Driver) setUserData(userDataFile string) error {
+	var data []byte
+	var err error
+	if userDataFile == "" {
+		return nil
+	}
+
+	if strings.HasPrefix(userDataFile, "http") {
+		data, err = d.readUserDataFromURL(userDataFile)
+
+		if err != nil {
+			return fmt.Errorf("Failed to read userdata from url %s: %s", d.UserDataFile, err)
+		}
+
+	} else {
+
+		data, err = ioutil.ReadFile(userDataFile)
+		if err != nil {
+			return fmt.Errorf("Failed to read user data file from path %s: %s", d.UserDataFile, err)
+		}
+	}
+
+	d.UserData = base64.StdEncoding.EncodeToString(data)
+
+	return nil
+}
+
+func (d *Driver) readUserDataFromURL(userDataURL string) ([]byte, error) {
+	c := &http.Client{}
+
+	resp, err := c.Get(userDataURL)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	return ioutil.ReadAll(resp.Body)
+
+}
+
+func (d *Driver) setProject(projectName string, projectID string) error {
+	d.Project = projectName
+	d.ProjectID = projectID
+
+	if d.Project == "" && d.ProjectID == "" {
+		return nil
+	}
+
+	cs := d.getClient()
+	var p *cloudstack.Project
+	var err error
+	if d.ProjectID != "" {
+		p, _, err = cs.Project.GetProjectByID(d.ProjectID)
+	} else {
+		p, _, err = cs.Project.GetProjectByName(d.Project)
+	}
+	if err != nil {
+		return fmt.Errorf("Invalid project: %s", err)
+	}
+
+	d.ProjectID = p.Id
+	d.Project = p.Name
+
+	log.Debugf("project id: %s", d.ProjectID)
+	log.Debugf("project name: %s", d.Project)
+
+	return nil
+}
+
+func (d *Driver) checkKeyPairByName() error {
+	cs := d.getClient()
+	log.Infof("Checking if SSH key pair (%v) already exists...", d.SSHKeyPair)
+	p := cs.SSH.NewListSSHKeyPairsParams()
+	p.SetName(d.SSHKeyPair)
+	if d.ProjectID != "" {
+		p.SetProjectid(d.ProjectID)
+	}
+	res, err := cs.SSH.ListSSHKeyPairs(p)
+	if err != nil {
+		return err
+	}
+	if res.Count > 0 {
+
+		if res.SSHKeyPairs[0].Name == d.SSHKeyPair {
+			keyExists = true
+			return nil
+		}
+	}
+
+	keyExists = false
+	return nil
+}
+
+func (d *Driver) getPubKeyFingerprint(pub string) (string, error) {
+
+	parts := strings.Fields(string(pub))
+	if len(parts) < 2 {
+		return "", errors.New("Bad pub key")
+	}
+
+	k, err := base64.StdEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", err
+	}
+
+	fp := md5.Sum([]byte(k))
+
+	var fSum []string
+
+	fmt.Print("MD5:")
+	for i, b := range fp {
+
+		fSum = append(fSum, fmt.Sprintf("%02x", b))
+		if i < len(fp)-1 {
+			fSum = append(fSum, ":")
+		}
+	}
+
+	return strings.Join(fSum, ""), nil
+
+}
+
+func (d *Driver) checkKeyPairByFingerprint(pubKey string) (bool, error) {
+	cs := d.getClient()
+
+	fp, err := d.getPubKeyFingerprint(pubKey)
+
+	if err != nil {
+		return false, err
+	}
+
+	log.Infof("Checking for matching public key fingerprints...", d.SSHKeyPair)
+	p := cs.SSH.NewListSSHKeyPairsParams()
+	p.SetFingerprint(fp)
+	if d.ProjectID != "" {
+		p.SetProjectid(d.ProjectID)
+	}
+	res, err := cs.SSH.ListSSHKeyPairs(p)
+	if err != nil {
+		return false, err
+	}
+	if res.Count > 0 {
+		for _, c := range res.SSHKeyPairs {
+			if c.Fingerprint == fp {
+				log.Infof("Found matching fingerprint, using key pair: %s", c.Name)
+				d.SSHKeyPair = c.Name
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+func (d *Driver) checkInstance() error {
+	cs := d.getClient()
+
+	log.Infof("Checking if instance (%v) already exists...", d.MachineName)
+
+	p := cs.VirtualMachine.NewListVirtualMachinesParams()
+	p.SetName(d.MachineName)
+	p.SetZoneid(d.ZoneID)
+	if d.ProjectID != "" {
+		p.SetProjectid(d.ProjectID)
+	}
+	res, err := cs.VirtualMachine.ListVirtualMachines(p)
+	if err != nil {
+		return err
+	}
+	if res.Count > 0 {
+		return fmt.Errorf("Instance (%v) already exists.", d.SSHKeyPair)
+	}
+	return nil
+}
+
+func (d *Driver) createKeyPair() error {
+	cs := d.getClient()
+	var publicKey []byte
+	var err error
+
+	if keyExists {
+		log.Infof("Using %s keypair", d.SSHKeyPair)
+		return nil
+	}
+
+	if d.UserDataFile != "" {
+		userDataContents, err := ioutil.ReadFile(d.UserDataFile)
+
+		if err != nil {
+			return err
+		}
+
+		sshKeyYaml := &UserDataYAML{}
+
+		if err != nil {
+			return err
+		}
+
+		if err := yaml.Unmarshal(userDataContents, sshKeyYaml); err != nil {
+			return err
+		}
+		log.Infof("Setting publicKey to %s", sshKeyYaml.SSHAuthorizedKeys[0])
+		publicKey = []byte(sshKeyYaml.SSHAuthorizedKeys[0])
+
+		if err := d.writeSSHKeys(sshKeyYaml.SSHKeys.RSAPrivate, sshKeyYaml.SSHAuthorizedKeys[0]); err != nil {
+			return err
+		}
+
+	} else {
+
+		if err := ssh.GenerateSSHKey(d.GetSSHKeyPath()); err != nil {
+			return err
+		}
+
+		publicKey, err = ioutil.ReadFile(d.GetSSHKeyPath() + ".pub")
+		if err != nil {
+			return err
+		}
+
+	}
+
+	exists, err := d.checkKeyPairByFingerprint(string(publicKey))
+
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		log.Infof("Registering SSH key pair %s", d.SSHKeyPair)
+		p := cs.SSH.NewRegisterSSHKeyPairParams(d.SSHKeyPair, string(publicKey))
+		if d.ProjectID != "" {
+			p.SetProjectid(d.ProjectID)
+		}
+		if _, err := cs.SSH.RegisterSSHKeyPair(p); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *Driver) deleteKeyPair() error {
+	cs := d.getClient()
+
+	log.Infof("Deleting SSH key pair...")
+
+	fp, err := ioutil.ReadFile(d.SSHKeyPath + ".pub")
+
+	if err != nil {
+		return err
+	}
+
+	inUse, err := d.checkKeyPairByFingerprint(string(fp))
+
+	if err != nil {
+		return err
+	}
+
+	if inUse {
+		log.Infof("Key %s is still in use for another VM, skipping key deletion", string(fp))
+		return nil
+	}
+
+	p := cs.SSH.NewDeleteSSHKeyPairParams(d.SSHKeyPair)
+	if d.ProjectID != "" {
+		p.SetProjectid(d.ProjectID)
+	}
+
+	if _, err := cs.SSH.DeleteSSHKeyPair(p); err != nil {
+		// Throw away the error because it most likely means that a key doesn't exist
+		// It is ok because we can use the same key for multiple machines.
+		log.Warnf("Key may not exist: %s", err)
+		return nil
+	}
+
+	return nil
+}
+
+func (d *Driver) deleteVolumes() error {
+	cs := d.getClient()
+
+	log.Info("Deleting volumes...")
+
+	p := cs.Volume.NewListVolumesParams()
+	p.SetVirtualmachineid(d.Id)
+	if d.ProjectID != "" {
+		p.SetProjectid(d.ProjectID)
+	}
+	volResponse, err := cs.Volume.ListVolumes(p)
+	if err != nil {
+		return err
+	}
+	for _, v := range volResponse.Volumes {
+		if v.Type != diskDatadisk {
+			continue
+		}
+		p := cs.Volume.NewDetachVolumeParams()
+		p.SetId(v.Id)
+		_, err := cs.Volume.DetachVolume(p)
+		if err != nil {
+			return err
+		}
+		_, err = cs.Volume.DeleteVolume(cs.Volume.NewDeleteVolumeParams(v.Id))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *Driver) associatePublicIP() error {
+	cs := d.getClient()
+	log.Infof("Associating public ip address...")
+	p := cs.Address.NewAssociateIpAddressParams()
+	p.SetZoneid(d.ZoneID)
+	if d.NetworkID != "" {
+		p.SetNetworkid(d.NetworkID)
+	}
+	if d.ProjectID != "" {
+		p.SetProjectid(d.ProjectID)
+	}
+	ip, err := cs.Address.AssociateIpAddress(p)
+	if err != nil {
+		return err
+	}
+	d.PublicIP = ip.Ipaddress
+	d.PublicIPID = ip.Id
+	d.DisassociatePublicIP = true
+
+	return nil
+}
+
+func (d *Driver) disassociatePublicIP() error {
+	if !d.DisassociatePublicIP {
+		return nil
+	}
+
+	cs := d.getClient()
+	log.Infof("Disassociating public ip address...")
+	p := cs.Address.NewDisassociateIpAddressParams(d.PublicIPID)
+	if _, err := cs.Address.DisassociateIpAddress(p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *Driver) enableStaticNat() error {
+	cs := d.getClient()
+	log.Infof("Enabling Static Nat...")
+	p := cs.NAT.NewEnableStaticNatParams(d.PublicIPID, d.Id)
+	if _, err := cs.NAT.EnableStaticNat(p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *Driver) configureFirewallRule(publicPort, privatePort int) error {
+	cs := d.getClient()
+
+	log.Debugf("Creating firewall rule ... : cidr list: %v, port %d", d.CIDRList, publicPort)
+	p := cs.Firewall.NewCreateFirewallRuleParams(d.PublicIPID, "tcp")
+	p.SetCidrlist(d.CIDRList)
+	p.SetStartport(publicPort)
+	p.SetEndport(publicPort)
+	rule, err := cs.Firewall.CreateFirewallRule(p)
+	if err != nil {
+		// If the error reports the port is already open, just ignore.
+		if !strings.Contains(err.Error(), fmt.Sprintf(
+			"The range specified, %d-%d, conflicts with rule", publicPort, publicPort)) {
+			return err
+		}
+	} else {
+		d.FirewallRuleIds = append(d.FirewallRuleIds, rule.Id)
+	}
+
+	return nil
+}
+
+func (d *Driver) configurePortForwardingRule(publicPort, privatePort int) error {
+	cs := d.getClient()
+
+	log.Debugf("Creating port forwarding rule ... : cidr list: %v, port %d", d.CIDRList, publicPort)
+	p := cs.Firewall.NewCreatePortForwardingRuleParams(
+		d.PublicIPID, privatePort, "tcp", publicPort, d.Id)
+	p.SetOpenfirewall(false)
+	if _, err := cs.Firewall.CreatePortForwardingRule(p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *Driver) configureFirewallRules() error {
+	log.Info("Creating firewall rule for ssh port ...")
+
+	if err := d.configureFirewallRule(22, 22); err != nil {
+		return err
+	}
+
+	log.Info("Creating firewall rule for docker port ...")
+	if err := d.configureFirewallRule(dockerPort, dockerPort); err != nil {
+		return err
+	}
+
+	if d.SwarmMaster {
+		log.Info("Creating firewall rule for swarm port ...")
+		if err := d.configureFirewallRule(swarmPort, swarmPort); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *Driver) deleteFirewallRules() error {
+	if len(d.FirewallRuleIds) > 0 {
+		log.Info("Removing firewall rules...")
+		for _, id := range d.FirewallRuleIds {
+			cs := d.getClient()
+			f := cs.Firewall.NewDeleteFirewallRuleParams(id)
+			if _, err := cs.Firewall.DeleteFirewallRule(f); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (d *Driver) configurePortForwardingRules() error {
+	log.Info("Creating port forwarding rule for ssh port ...")
+
+	if err := d.configurePortForwardingRule(22, 22); err != nil {
+		return err
+	}
+
+	log.Info("Creating port forwarding rule for docker port ...")
+	if err := d.configurePortForwardingRule(dockerPort, dockerPort); err != nil {
+		return err
+	}
+
+	if d.SwarmMaster {
+		log.Info("Creating port forwarding rule for swarm port ...")
+		if err := d.configurePortForwardingRule(swarmPort, swarmPort); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *Driver) createSecurityGroup() error {
+	log.Debugf("Creating security group ...")
+	cs := d.getClient()
+
+	p1 := cs.SecurityGroup.NewCreateSecurityGroupParams(d.MachineName)
+	if d.ProjectID != "" {
+		p1.SetProjectid(d.ProjectID)
+	}
+	if _, err := cs.SecurityGroup.CreateSecurityGroup(p1); err != nil {
+		return err
+	}
+
+	p2 := cs.SecurityGroup.NewAuthorizeSecurityGroupIngressParams()
+	p2.SetSecuritygroupname(d.MachineName)
+	p2.SetProtocol("tcp")
+	p2.SetCidrlist(d.CIDRList)
+
+	p2.SetStartport(22)
+	p2.SetEndport(22)
+	if d.ProjectID != "" {
+		p2.SetProjectid(d.ProjectID)
+	}
+	if _, err := cs.SecurityGroup.AuthorizeSecurityGroupIngress(p2); err != nil {
+		return err
+	}
+
+	p2.SetStartport(dockerPort)
+	p2.SetEndport(dockerPort)
+	if _, err := cs.SecurityGroup.AuthorizeSecurityGroupIngress(p2); err != nil {
+		return err
+	}
+
+	if d.SwarmMaster {
+		p2.SetStartport(swarmPort)
+		p2.SetEndport(swarmPort)
+		if _, err := cs.SecurityGroup.AuthorizeSecurityGroupIngress(p2); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *Driver) deleteSecurityGroup() error {
+	log.Debugf("Deleting security group ...")
+	cs := d.getClient()
+
+	p := cs.SecurityGroup.NewDeleteSecurityGroupParams()
+	p.SetName(d.MachineName)
+	if d.ProjectID != "" {
+		p.SetProjectid(d.ProjectID)
+	}
+	if _, err := cs.SecurityGroup.DeleteSecurityGroup(p); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *Driver) createTags() error {
+	log.Info("Creating resource tags ...")
+	cs := d.getClient()
+	tags := make(map[string]string)
+	for _, t := range d.Tags {
+		parts := strings.SplitN(t, ":", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid resource tags format, each tag must be on the format KEY:VALUE")
+		}
+		tags[parts[0]] = parts[1]
+	}
+	params := cs.Resourcetags.NewCreateTagsParams([]string{d.Id}, "UserVm", tags)
+	_, err := cs.Resourcetags.CreateTags(params)
+	return err
+}
+
+func (d *Driver) setParams(c *cloudstack.CloudStackClient, p interface{}) error {
+	if o, ok := p.(interface {
+		SetProjectid(string)
+	}); ok && d.ProjectID != "" {
+		o.SetProjectid(d.ProjectID)
+	}
+	if o, ok := p.(interface {
+		SetZoneid(string)
+	}); ok && d.ZoneID != "" {
+		o.SetZoneid(d.ZoneID)
+	}
+	return nil
+}
+func (d *Driver) writeSSHKeys(priv, pub string) error {
+
+	if priv == "" {
+		return errors.New("A private key must be passed in the userdata file under the ssh_keys")
+	}
+
+	log.Infof("Writing first private key found in userdata file to %s", d.StorePath)
+	if err := ioutil.WriteFile(d.GetSSHKeyPath(), []byte(priv), 0600); err != nil {
+		return err
+	}
+
+	log.Infof("Writing public key to id_rsa to %s.pub", d.GetSSHKeyPath())
+	if err := ioutil.WriteFile(fmt.Sprintf("%s.pub", d.GetSSHKeyPath()), []byte(pub), 0600); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pcextreme.go
+++ b/pcextreme.go
@@ -47,7 +47,6 @@ type Driver struct {
 	SSHKeyPair        string
 	CIDRList          []string
 	FirewallRuleIds   []string
-	Expunge           bool
 	Template          string
 	TemplateID        string
 	ServiceOffering   string
@@ -250,7 +249,6 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.JobTimeOut = int64(flags.Int("pcextreme-timeout"))
 	d.SSHUser = flags.String("pcextreme-ssh-user")
 	d.CIDRList = flags.StringSlice("pcextreme-cidr")
-	d.Expunge = flags.Bool("pcextreme-expunge")
 	d.Tags = flags.StringSlice("pcextreme-resource-tag")
 	d.DeleteVolumes = flags.Bool("pcextreme-delete-volumes")
 	d.DiskSize = flags.Int("pcextreme-disk-size")
@@ -432,7 +430,6 @@ func (d *Driver) Create() error {
 func (d *Driver) Remove() error {
 	cs := d.getClient()
 	p := cs.VirtualMachine.NewDestroyVirtualMachineParams(d.Id)
-	p.SetExpunge(d.Expunge)
 	if err := d.deleteFirewallRules(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Delete certain settings & flags that aren't supported when running on PCextreme public cloud.

This contains:
Advanced networking (private IP, public IP requesting, port forwarding & firewall)
Expunging (this is locked and will happen automatically after n days)
Projects (Not available)